### PR TITLE
Refuse to receive worker messages once dead.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firetruss",
-  "version": "7.8.3",
+  "version": "7.8.4",
   "description": "Advanced data sync layer for Firebase and Vue.js",
   "scripts": {
     "update": "yarn upgrade-interactive --latest",

--- a/src/Bridge.js
+++ b/src/Bridge.js
@@ -153,6 +153,7 @@ export default class Bridge {
   }
 
   _receive(event) {
+    if (this._dead) return;
     if (this._suspended) {
       this._inboundMessages = this._inboundMessages.concat(event.data);
     } else {


### PR DESCRIPTION
Addresses https://reviewableio.sentry.io/issues/7326447743.  It appears that it's possible for a worker to send the `crash` message (which clears out the `deferreds` table), but then try to send more responses afterwards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/firetruss/37)
<!-- Reviewable:end -->
